### PR TITLE
修复定时器的分钟数溢出问题

### DIFF
--- a/src/main/java/com/shuzijun/leetcode/plugin/timer/TimerBarWidget.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/timer/TimerBarWidget.java
@@ -55,7 +55,7 @@ public class TimerBarWidget implements CustomStatusBarWidget {
     });
 
     private String time() {
-        return String.format("[%s]%02d:%02d:%02d", name, second / 60 / 60, second / 60, second % 60);
+        return String.format("[%s]%02d:%02d:%02d", name, second / 60 / 60, second / 60 % 60, second % 60);
     }
 
     @Override


### PR DESCRIPTION
Bug描述：当定时器计时超过一个小时以后，分钟数会*持续增长下去*，超出60。
（很小的一个问题）