### PR TITLE
提议修改代码范围开始与结束标记

### DIFF
--- a/doc/CustomCode_ZH.md
+++ b/doc/CustomCode_ZH.md
@@ -24,8 +24,8 @@
 
 ## 注意  
   在生成的自定义代码中包含两行关键信息:  
-  - `leetcode submit region begin(Prohibit modification and deletion)`:提交到leetcode进行验证的代码开始标记  
-  - `leetcode submit region end(Prohibit modification and deletion)`:提交到leetcode进行验证的代码结束标记  
+  - `-----BEGIN LEETCODE SUBMIT REGION (Do Not Modify or Delete)-----`:提交到leetcode进行验证的代码开始标记  
+  - `-----END LEETCODE SUBMIT REGION (Do Not Modify or Delete)-----`:提交到leetcode进行验证的代码结束标记  
   这两行标记标示了提交到leetcode服务器进行验证的代码范围,在此范围内只允许有出现与题目解答相关的内容，出现其他内容可能导致leetcode验证不通过。  
   除了此范围内，其他区域是可以任意填写的，内容不会提交到leetcode，可以增加一些可以本地调试的内容，例如:import java.util.Arrays;  
   所以，这两行内容是不能被删除和修改的，否则将识别不到提交的内容。

--- a/src/main/java/com/shuzijun/leetcode/plugin/model/Constant.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/model/Constant.java
@@ -62,8 +62,8 @@ public class Constant {
     /**
      * 提交代码标识 submit
      */
-    public static final String SUBMIT_REGION_BEGIN = "leetcode submit region begin(Prohibit modification and deletion)";
-    public static final String SUBMIT_REGION_END = "leetcode submit region end(Prohibit modification and deletion)";
+    public static final String SUBMIT_REGION_BEGIN = "-----BEGIN LEETCODE SUBMIT REGION (Do Not Modify or Delete)-----";
+    public static final String SUBMIT_REGION_END = "-----END LEETCODE SUBMIT REGION (Do Not Modify or Delete)-----";
 
     /**
      * 配置文件版本记录


### PR DESCRIPTION
其实我们现在的机制是完全有效的，我主要纠结两个小点：
- 现在用的这行英文括号里的提示文字（禁止修改与删除）的用法稍微有点不规范。
- 现行的文字标记不是很醒目，看起来也不是特别正式。

PR里的格式主要参照的是[PGP公钥](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/4/html/Step_by_Step_Guide/s1-gnupg-export.html)的那种格式。为了保持内容上的一致，把禁止修改的提示信息也加在了后面的括号里。

实话说，改这种东西可以改，但也没必要改。主要是有个人喜好问题和版本兼容性问题，所以改不改都没有关系，以后某个大版本更新再改同样也成。