### PR TITLE
Fix permanently disabled JCEF checkbox in plugin settings

### DIFF
--- a/src/main/java/com/shuzijun/leetcode/plugin/actions/toolbar/LoginAction.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/actions/toolbar/LoginAction.java
@@ -65,7 +65,7 @@ public class LoginAction extends AbstractAction {
                 @Override
                 public void run() {
                     LoginFrame loginFrame;
-                    if (HttpLogin.isSupportedJcef()) {
+                    if (HttpLogin.isEnabledJcef()) {
                         loginFrame = new JcefLogin(anActionEvent.getProject(), tree);
                     } else {
                         loginFrame = new CookieLogin(anActionEvent.getProject(), tree);

--- a/src/main/java/com/shuzijun/leetcode/plugin/window/HttpLogin.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/window/HttpLogin.java
@@ -17,6 +17,7 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.HttpCookie;
 import java.util.List;
@@ -142,15 +143,17 @@ public class HttpLogin {
         });
     }
 
+    public static boolean isEnabledJcef() {
+        Config config = PersistentConfig.getInstance().getInitConfig();
+        return config != null && config.getJcef() && isSupportedJcef();
+    }
+
     public static boolean isSupportedJcef() {
         try {
             Class<?> JBCefAppClass = Class.forName("com.intellij.ui.jcef.JBCefApp");
             Method method = JBCefAppClass.getMethod("isSupported");
-            boolean supported = (boolean) method.invoke(null);
-
-            Config config = PersistentConfig.getInstance().getInitConfig();
-            return config.getJcef() && supported;
-        } catch (Throwable e) {
+            return (boolean) method.invoke(null);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             return Boolean.FALSE;
         }
     }


### PR DESCRIPTION
Split HttpLogin.isSupportedJcef into two methods: .isSupportedJcef and isEnabledJcef. JCEF checkbox is disabled only if JCEF is not supported in current configuration.
Fixes https://github.com/shuzijun/leetcode-editor/issues/266