### PR TITLE
在获取题目内容的正则匹配加了一个\n\n，可以提升一下观感

### DIFF
--- a/src/main/java/com/shuzijun/leetcode/plugin/utils/CommentUtils.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/utils/CommentUtils.java
@@ -10,7 +10,7 @@ import org.jsoup.Jsoup;
 public class CommentUtils {
 
     public static String createComment(String html, CodeTypeEnum codeTypeEnum) {
-        String body = codeTypeEnum.getComment() + Jsoup.parse(html.replaceAll("(\\r\\n|\\r|\\n|\\n\\r)", "\\\\n")).text().replaceAll("\\\\n", "\n" + codeTypeEnum.getComment());
+        String body = codeTypeEnum.getComment() + Jsoup.parse(html.replaceAll("(\\n\\n|\\r\\n|\\r|\\n|\\n\\r)", "\\\\n")).text().replaceAll("\\\\n", "\n" + codeTypeEnum.getComment());
         String[] lines = body.split("\n");
         StringBuilder sb = new StringBuilder();
         for (String line : lines) {


### PR DESCRIPTION
写解析完整的标签正则太麻烦了，引入标签的解析库感觉也不好……先用这个粗陋的顶着

改动前：

![image](https://user-images.githubusercontent.com/40252940/104517915-d8771080-5631-11eb-9321-b8b73186b8cf.png)

改动后：

![image](https://user-images.githubusercontent.com/40252940/104517955-ea58b380-5631-11eb-9d38-0210e7b9a374.png)

