### PR TITLE
Prevent LeetCode operations from freezing the IDE

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
@@ -112,6 +113,10 @@ changelog {
 
 
 tasks {
+    withType<JavaCompile>().configureEach {
+        options.encoding = "UTF-8"
+    }
+
     wrapper {
         gradleVersion = providers.gradleProperty("gradleVersion").get()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,8 @@
 pluginGroup = com.shuzijun.leetcode
 pluginName = leetcode-editor
 pluginVersion = 8.16
+gradleVersion = 8.6
+kotlin.stdlib.default.dependency = false
 
 pluginSinceBuild = 223.0
 pluginUntilBuild =

--- a/src/main/java/com/shuzijun/leetcode/plugin/actions/toolbar/ClearAllAction.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/actions/toolbar/ClearAllAction.java
@@ -12,6 +12,7 @@ import com.intellij.ui.components.JBPanel;
 import com.shuzijun.leetcode.plugin.actions.AbstractAction;
 import com.shuzijun.leetcode.plugin.model.Config;
 import com.shuzijun.leetcode.plugin.setting.PersistentConfig;
+import com.shuzijun.leetcode.plugin.setting.ProjectConfig;
 import com.shuzijun.leetcode.plugin.utils.LogUtils;
 import com.shuzijun.leetcode.plugin.utils.MessageUtils;
 import com.shuzijun.leetcode.plugin.utils.PropertiesUtils;
@@ -19,72 +20,126 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * @author shuzijun
+ * Clears generated files. AbstractAction already invokes this method on a background thread, so
+ * only the confirmation dialog and editor operations are marshalled to the UI thread.
  */
 public class ClearAllAction extends AbstractAction implements DumbAware {
     @Override
     public void actionPerformed(AnActionEvent anActionEvent, Config config) {
-
+        Project project = anActionEvent.getProject();
+        AtomicBoolean confirmed = new AtomicBoolean();
         ApplicationManager.getApplication().invokeAndWait(() -> {
-            ClearAllWarningPanel dialog = new ClearAllWarningPanel(anActionEvent.getProject());
+            ClearAllWarningPanel dialog = new ClearAllWarningPanel(project);
             dialog.setTitle("Clear All");
-
-            if (dialog.showAndGet()) {
-                String filePath = PersistentConfig.getInstance().getTempFilePath();
-
-                File file = new File(filePath);
-                if (!file.exists() || !file.isDirectory()) {
-                    MessageUtils.getInstance(anActionEvent.getProject()).showInfoMsg("info", PropertiesUtils.getInfo("clear.success"));
-                    return;
-                }
-
-                try {
-                    delFile(file, anActionEvent.getProject());
-                    MessageUtils.getInstance(anActionEvent.getProject()).showInfoMsg("info", PropertiesUtils.getInfo("clear.success"));
-                } catch (Exception ee) {
-                    LogUtils.LOG.error("清理文件错误", ee);
-                    MessageUtils.getInstance(anActionEvent.getProject()).showErrorMsg("error", PropertiesUtils.getInfo("clear.failed"));
-                }
-            }
+            confirmed.set(dialog.showAndGet());
         });
-
-    }
-
-    public void delFile(File file, Project project) {
-        if (!file.exists()) {
+        if (!confirmed.get()) {
             return;
         }
 
-        if (file.isDirectory()) {
-            File[] files = file.listFiles();
-            for (File f : files) {
-                delFile(f, project);
-            }
-        }
+        Path root;
         try {
-            VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
-            if (FileEditorManager.getInstance(project).isFileOpen(vf)) {
-                FileEditorManager.getInstance(project).closeFile(vf);
-            }
-            file.delete();
-        } catch (Exception e) {
-            LogUtils.LOG.error("Error deleting file", e);
+            root = Paths.get(PersistentConfig.getInstance().getTempFilePath()).toAbsolutePath().normalize();
+        } catch (RuntimeException e) {
+            showFailure(project, e);
+            return;
+        }
+        if (!Files.isDirectory(root)) {
+            showSuccess(project);
+            return;
+        }
+        // Never allow a misconfigured cache path to delete an entire filesystem volume.
+        if (root.getParent() == null) {
+            showFailure(project, new IOException("Refusing to clear a filesystem root: " + root));
+            return;
         }
 
+        VirtualFile rootFile = LocalFileSystem.getInstance().findFileByIoFile(root.toFile());
+        VirtualFile refreshTarget = rootFile == null ? null : rootFile.getParent();
+        closeEditorsUnder(project, root);
+        try {
+            deleteTree(root);
+            ProjectConfig projectConfig = ProjectConfig.getInstance(project);
+            if (projectConfig != null) {
+                projectConfig.pruneStaleEntries(project.getBasePath());
+            }
+            refreshAsync(refreshTarget);
+            showSuccess(project);
+        } catch (IOException e) {
+            LogUtils.LOG.error("Error clearing generated LeetCode files", e);
+            refreshAsync(refreshTarget);
+            MessageUtils.getInstance(project).showErrorMsg("error", PropertiesUtils.getInfo("clear.failed"));
+        }
     }
 
-    private class ClearAllWarningPanel extends DialogWrapper {
+    private static void closeEditorsUnder(Project project, Path root) {
+        ApplicationManager.getApplication().invokeAndWait(() -> {
+            FileEditorManager editorManager = FileEditorManager.getInstance(project);
+            for (VirtualFile file : editorManager.getOpenFiles()) {
+                try {
+                    Path openPath = Paths.get(file.getPath()).toAbsolutePath().normalize();
+                    if (openPath.startsWith(root)) {
+                        editorManager.closeFile(file);
+                    }
+                } catch (RuntimeException ignored) {
+                    // Non-local virtual files are unrelated to the generated-file directory.
+                }
+            }
+        });
+    }
 
-        private JPanel jpanel;
+    private static void deleteTree(Path root) throws IOException {
+        Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.deleteIfExists(file);
+                return FileVisitResult.CONTINUE;
+            }
 
-        public ClearAllWarningPanel(@Nullable Project project) {
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                if (exc != null) {
+                    throw exc;
+                }
+                Files.deleteIfExists(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static void refreshAsync(@Nullable VirtualFile refreshTarget) {
+        if (refreshTarget != null) {
+            refreshTarget.refresh(true, false);
+        }
+    }
+
+    private static void showSuccess(Project project) {
+        MessageUtils.getInstance(project).showInfoMsg("info", PropertiesUtils.getInfo("clear.success"));
+    }
+
+    private static void showFailure(Project project, Exception error) {
+        LogUtils.LOG.error("Invalid LeetCode generated-file directory", error);
+        MessageUtils.getInstance(project).showErrorMsg("error", PropertiesUtils.getInfo("clear.failed"));
+    }
+
+    private static class ClearAllWarningPanel extends DialogWrapper {
+        private final JPanel panel;
+
+        ClearAllWarningPanel(@Nullable Project project) {
             super(project, true);
-            jpanel = new JBPanel();
-            jpanel.add(new JLabel("Clear All File？"));
-            jpanel.setMinimumSize(new Dimension(200, 100));
+            panel = new JBPanel<>();
+            panel.add(new JLabel("Clear all generated LeetCode files?"));
+            panel.setMinimumSize(new Dimension(260, 100));
             setModal(true);
             init();
         }
@@ -92,7 +147,7 @@ public class ClearAllAction extends AbstractAction implements DumbAware {
         @Nullable
         @Override
         protected JComponent createCenterPanel() {
-            return jpanel;
+            return panel;
         }
     }
 }

--- a/src/main/java/com/shuzijun/leetcode/plugin/actions/tree/ClearOneAction.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/actions/tree/ClearOneAction.java
@@ -9,11 +9,15 @@ import com.shuzijun.leetcode.plugin.model.CodeTypeEnum;
 import com.shuzijun.leetcode.plugin.model.Config;
 import com.shuzijun.leetcode.plugin.model.Question;
 import com.shuzijun.leetcode.plugin.setting.PersistentConfig;
+import com.shuzijun.leetcode.plugin.setting.ProjectConfig;
+import com.shuzijun.leetcode.plugin.utils.LogUtils;
 import com.shuzijun.leetcode.plugin.utils.MessageUtils;
 import com.shuzijun.leetcode.plugin.utils.PropertiesUtils;
 import com.shuzijun.leetcode.plugin.utils.VelocityUtils;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  * @author shuzijun
@@ -33,13 +37,26 @@ public class ClearOneAction extends AbstractTreeAction {
 
         File file = new File(filePath);
         if (file.exists()) {
+            VirtualFile vf = LocalFileSystem.getInstance().findFileByIoFile(file);
             ApplicationManager.getApplication().invokeAndWait(() -> {
-                VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
-                if (FileEditorManager.getInstance(anActionEvent.getProject()).isFileOpen(vf)) {
+                if (vf != null && FileEditorManager.getInstance(anActionEvent.getProject()).isFileOpen(vf)) {
                     FileEditorManager.getInstance(anActionEvent.getProject()).closeFile(vf);
                 }
-                file.delete();
             });
+            try {
+                Files.deleteIfExists(file.toPath());
+                ProjectConfig projectConfig = ProjectConfig.getInstance(anActionEvent.getProject());
+                if (projectConfig != null) {
+                    projectConfig.removeEditor(file.getPath());
+                }
+                if (vf != null && vf.getParent() != null) {
+                    vf.getParent().refresh(true, false);
+                }
+            } catch (IOException e) {
+                LogUtils.LOG.error("Error deleting generated LeetCode file", e);
+                MessageUtils.getInstance(anActionEvent.getProject()).showErrorMsg(question.getFormTitle(), PropertiesUtils.getInfo("clear.failed"));
+                return;
+            }
         }
         MessageUtils.getInstance(anActionEvent.getProject()).showInfoMsg(question.getFormTitle(), PropertiesUtils.getInfo("clear.success"));
 

--- a/src/main/java/com/shuzijun/leetcode/plugin/editor/QuestionEditorIconProvider.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/editor/QuestionEditorIconProvider.java
@@ -13,7 +13,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.io.File;
 
 /**
  * @author shuzijun
@@ -32,10 +31,6 @@ public class QuestionEditorIconProvider implements FileIconPatcher {
             }
             LeetcodeEditor leetcodeEditor = ProjectConfig.getInstance(project).getEditor(file.getPath(), config.getUrl());
             if (leetcodeEditor == null || StringUtils.isBlank(leetcodeEditor.getContentPath())) {
-                return baseIcon;
-            }
-            File contentFile = new File(leetcodeEditor.getContentPath());
-            if (!contentFile.exists()) {
                 return baseIcon;
             }
         } catch (Throwable e) {

--- a/src/main/java/com/shuzijun/leetcode/plugin/editor/QuestionEditorProvider.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/editor/QuestionEditorProvider.java
@@ -18,8 +18,6 @@ import com.shuzijun.leetcode.plugin.utils.LogUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
-
 /**
  * @author shuzijun
  */
@@ -38,10 +36,6 @@ public class QuestionEditorProvider extends SplitTextEditorProvider {
             }
             LeetcodeEditor leetcodeEditor = ProjectConfig.getInstance(project).getEditor(file.getPath());
             if (leetcodeEditor == null || StringUtils.isBlank(leetcodeEditor.getContentPath())) {
-                return false;
-            }
-            File contentFile = new File(leetcodeEditor.getContentPath());
-            if (!contentFile.exists()) {
                 return false;
             }
         } catch (Throwable e) {

--- a/src/main/java/com/shuzijun/leetcode/plugin/editor/QuestionEditorTabTitleProvider.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/editor/QuestionEditorTabTitleProvider.java
@@ -29,17 +29,20 @@ public class QuestionEditorTabTitleProvider implements EditorTabTitleProvider {
             LeetcodeEditor leetcodeEditor = ProjectConfig.getInstance(project).getEditor(file.getPath(), config.getUrl());
             if (leetcodeEditor == null || StringUtils.isBlank(leetcodeEditor.getContentPath())) {
                 return null;
-            } else {
-                Question question = QuestionManager.getQuestionByTitleSlug(leetcodeEditor.getTitleSlug(), project);
-                if (question == null) {
-                    return null;
-                } else {
-                    return question.getFormTitle();
-                }
             }
+
+            // IDEA calls tab title providers while restoring editors during startup. This
+            // callback must stay local: waiting for LeetCode here freezes the whole IDE.
+            Question question = QuestionManager.getCachedQuestionByTitleSlug(
+                    leetcodeEditor.getTitleSlug(), leetcodeEditor.getHost());
+            return resolveLocalTitle(question, file.getNameWithoutExtension());
         } catch (Throwable e) {
-            LogUtils.LOG.error("QuestionEditorIconProvider -> patchIcon", e);
+            LogUtils.LOG.error("QuestionEditorTabTitleProvider -> getEditorTabTitle", e);
             return null;
         }
+    }
+
+    static String resolveLocalTitle(@Nullable Question cachedQuestion, @NotNull String fallbackTitle) {
+        return cachedQuestion == null ? fallbackTitle : cachedQuestion.getFormTitle();
     }
 }

--- a/src/main/java/com/shuzijun/leetcode/plugin/editor/converge/ContentProvider.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/editor/converge/ContentProvider.java
@@ -1,6 +1,5 @@
 package com.shuzijun.leetcode.plugin.editor.converge;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -25,12 +24,14 @@ public class ContentProvider extends LCVProvider {
     @Override
     public @NotNull FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile file) {
         LeetcodeEditor leetcodeEditor = ProjectConfig.getInstance(project).getEditor(file.getPath());
-
-        VirtualFile contentVf;
-        try {
-            contentVf = ApplicationManager.getApplication().executeOnPooledThread(() -> LocalFileSystem.getInstance().refreshAndFindFileByIoFile(new File(leetcodeEditor.getContentPath()))).get();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        if (leetcodeEditor == null || leetcodeEditor.getContentPath() == null) {
+            throw new IllegalStateException("Missing LeetCode editor metadata for " + file.getPath());
+        }
+        // Generated content is refreshed when it is created. Avoid waiting on a background Future
+        // from the editor-creation path, which is normally invoked on the UI thread.
+        VirtualFile contentVf = LocalFileSystem.getInstance().findFileByIoFile(new File(leetcodeEditor.getContentPath()));
+        if (contentVf == null) {
+            throw new IllegalStateException("LeetCode content file is not available in VFS: " + leetcodeEditor.getContentPath());
         }
         return super.createEditor(project, contentVf);
     }

--- a/src/main/java/com/shuzijun/leetcode/plugin/editor/converge/NotePreview.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/editor/converge/NotePreview.java
@@ -21,6 +21,7 @@ import com.shuzijun.leetcode.plugin.manager.NoteManager;
 import com.shuzijun.leetcode.plugin.model.LeetcodeEditor;
 import com.shuzijun.leetcode.plugin.model.PluginConstant;
 import com.shuzijun.leetcode.plugin.utils.FileEditorProviderReflection;
+import com.shuzijun.leetcode.plugin.utils.AsyncUiUtils;
 import com.shuzijun.leetcode.plugin.utils.URLUtils;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -68,12 +69,17 @@ public class NotePreview extends UserDataHolderBase implements FileEditor {
         ApplicationManager.getApplication().invokeLater(() -> {
             JBLabel loadingLabel = new JBLabel("Loading......");
             myComponent.addToCenter(loadingLabel);
-            try {
-                File file = ApplicationManager.getApplication().executeOnPooledThread(() -> NoteManager.show(leetcodeEditor.getTitleSlug(), project, false)).get();
-                if (file == null || !file.exists()) {
+            AsyncUiUtils.load(project, this, () -> {
+                File file = NoteManager.show(leetcodeEditor.getTitleSlug(), project, false);
+                return file == null || !file.exists()
+                        ? null
+                        : LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
+            }, (vf, error) -> {
+                if (error != null) {
+                    myComponent.addToCenter(new JBLabel(error.getMessage()));
+                } else if (vf == null) {
                     myComponent.addToCenter(new JBLabel("No note"));
                 } else {
-                    VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
                     FileEditorProvider[] editorProviders = FileEditorProviderReflection.getProviders(project, vf);
 
                     if (editorProviders != null && editorProviders.length > 0) {
@@ -85,13 +91,11 @@ public class NotePreview extends UserDataHolderBase implements FileEditor {
                     }
                     myComponent.addToCenter(fileEditor.getComponent());
                     myComponent.addToTop(createToolbarWrapper(fileEditor.getComponent()));
-
                 }
-            } catch (Exception e) {
-                myComponent.addToCenter(new JBLabel(e.getMessage()));
-            } finally {
                 myComponent.remove(loadingLabel);
-            }
+                myComponent.revalidate();
+                myComponent.repaint();
+            });
         });
     }
 
@@ -150,7 +154,7 @@ public class NotePreview extends UserDataHolderBase implements FileEditor {
 
     @Override
     public boolean isValid() {
-        return false;
+        return !project.isDisposed();
     }
 
     @Override
@@ -170,9 +174,7 @@ public class NotePreview extends UserDataHolderBase implements FileEditor {
 
     @Override
     public void dispose() {
-        if (fileEditor != null) {
-            Disposer.dispose(fileEditor);
-        }
+        fileEditor = null;
     }
 
     @Override

--- a/src/main/java/com/shuzijun/leetcode/plugin/editor/converge/SolutionPreview.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/editor/converge/SolutionPreview.java
@@ -21,6 +21,7 @@ import com.shuzijun.leetcode.plugin.manager.ArticleManager;
 import com.shuzijun.leetcode.plugin.manager.QuestionManager;
 import com.shuzijun.leetcode.plugin.model.*;
 import com.shuzijun.leetcode.plugin.utils.FileEditorProviderReflection;
+import com.shuzijun.leetcode.plugin.utils.AsyncUiUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nls;
@@ -87,11 +88,23 @@ public class SolutionPreview extends UserDataHolderBase implements FileEditor {
     private void initComponent(String defaultSlug) {
         isLoad = true;
         ApplicationManager.getApplication().invokeLater(() -> {
-            JBLabel loadingLabel = new JBLabel("Loading......");
-            mySplitter.setFirstComponent(loadingLabel);
-            try {
-                question = QuestionManager.getQuestionByTitleSlug(leetcodeEditor.getTitleSlug(), project);
-
+            mySplitter.setFirstComponent(new JBLabel("Loading......"));
+            AsyncUiUtils.load(project, this, () -> {
+                Question loadedQuestion = QuestionManager.getQuestionByTitleSlug(leetcodeEditor.getTitleSlug(), project);
+                List<Solution> loadedSolutions = null;
+                if (loadedQuestion != null && Constant.ARTICLE_LIVE_LIST.equals(loadedQuestion.getArticleLive())) {
+                    loadedSolutions = ArticleManager.getSolutionList(loadedQuestion.getTitleSlug(), project);
+                }
+                return new InitialData(loadedQuestion, loadedSolutions);
+            }, (data, error) -> {
+                if (error != null) {
+                    myLayout = SplitFileEditor.SplitEditorLayout.FIRST;
+                    adjustEditorsVisibility();
+                    mySplitter.setFirstComponent(new JBLabel(error.getMessage()));
+                    return;
+                }
+                question = data.question;
+                solutionList = data.solutions;
                 if (question == null || Constant.ARTICLE_LIVE_NONE.equals(question.getArticleLive())) {
                     mySplitter.setFirstComponent(new JBLabel("No question or no solution"));
                 } else if (Constant.ARTICLE_LIVE_ONE.equals(question.getArticleLive())) {
@@ -99,7 +112,6 @@ public class SolutionPreview extends UserDataHolderBase implements FileEditor {
                     myLayout = SplitFileEditor.SplitEditorLayout.SECOND;
                     adjustEditorsVisibility();
                 } else if (Constant.ARTICLE_LIVE_LIST.equals(question.getArticleLive())) {
-                    solutionList = ApplicationManager.getApplication().executeOnPooledThread(() -> ArticleManager.getSolutionList(question.getTitleSlug(), project)).get();
                     if (CollectionUtils.isEmpty(solutionList)) {
                         mySplitter.setFirstComponent(new JBLabel("no solution"));
                     } else {
@@ -145,13 +157,7 @@ public class SolutionPreview extends UserDataHolderBase implements FileEditor {
                 } else {
                     mySplitter.setFirstComponent(new JBLabel("no solution"));
                 }
-            } catch (Exception e) {
-                myLayout = SplitFileEditor.SplitEditorLayout.FIRST;
-                adjustEditorsVisibility();
-                mySplitter.setFirstComponent(new JBLabel(e.getMessage()));
-            } finally {
-                mySplitter.remove(loadingLabel);
-            }
+            });
         });
     }
 
@@ -169,15 +175,29 @@ public class SolutionPreview extends UserDataHolderBase implements FileEditor {
         }
     }
 
-    private void openArticle() throws InterruptedException, java.util.concurrent.ExecutionException {
-        File file = ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            return ArticleManager.openArticle(question.getTitleSlug(), question.getArticleSlug(), project, false);
-        }).get();
-        if (file == null || !file.exists()) {
-            mySplitter.setSecondComponent(new JBLabel("no solution"));
-        } else {
-            VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
+    private void openArticle() {
+        if (question == null) {
+            return;
+        }
+        String titleSlug = question.getTitleSlug();
+        String articleSlug = question.getArticleSlug();
+        mySplitter.setSecondComponent(new JBLabel("Loading......"));
+        AsyncUiUtils.load(project, this, () -> {
+            File file = ArticleManager.openArticle(titleSlug, articleSlug, project, false);
+            return file == null || !file.exists()
+                    ? null
+                    : LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
+        }, (vf, error) -> {
+            if (error != null) {
+                mySplitter.setSecondComponent(new JBLabel(error.getMessage()));
+            } else if (vf == null) {
+                mySplitter.setSecondComponent(new JBLabel("no solution"));
+            } else {
             FileEditorProvider[] editorProviders = FileEditorProviderReflection.getProviders(project, vf);
+            if (editorProviders == null || editorProviders.length == 0) {
+                mySplitter.setSecondComponent(new JBLabel("No editor available for solution"));
+                return;
+            }
             FileEditor newEditor = editorProviders[0].createEditor(project, vf);
             if (newEditor == fileEditor) {
                 return;
@@ -194,7 +214,8 @@ public class SolutionPreview extends UserDataHolderBase implements FileEditor {
                 secondComponent.addToTop(createToolbarWrapper(fileEditor.getComponent()));
             }
             mySplitter.setSecondComponent(secondComponent);
-        }
+            }
+        });
     }
 
     private SplitEditorToolbar createToolbarWrapper(JComponent targetComponentForActions) {
@@ -278,7 +299,7 @@ public class SolutionPreview extends UserDataHolderBase implements FileEditor {
 
     @Override
     public boolean isValid() {
-        return false;
+        return !project.isDisposed();
     }
 
     @Override
@@ -298,9 +319,7 @@ public class SolutionPreview extends UserDataHolderBase implements FileEditor {
 
     @Override
     public void dispose() {
-        if (fileEditor != null) {
-            Disposer.dispose(fileEditor);
-        }
+        fileEditor = null;
     }
 
     @Override
@@ -346,6 +365,16 @@ public class SolutionPreview extends UserDataHolderBase implements FileEditor {
         @Override
         public String getColumnName(int column) {
             return columnNames[column];
+        }
+    }
+
+    private static class InitialData {
+        private final Question question;
+        private final List<Solution> solutions;
+
+        private InitialData(Question question, List<Solution> solutions) {
+            this.question = question;
+            this.solutions = solutions;
         }
     }
 }

--- a/src/main/java/com/shuzijun/leetcode/plugin/editor/converge/SubmissionsPreview.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/editor/converge/SubmissionsPreview.java
@@ -26,6 +26,7 @@ import com.shuzijun.leetcode.plugin.model.PluginConstant;
 import com.shuzijun.leetcode.plugin.model.Question;
 import com.shuzijun.leetcode.plugin.model.Submission;
 import com.shuzijun.leetcode.plugin.utils.FileEditorProviderReflection;
+import com.shuzijun.leetcode.plugin.utils.AsyncUiUtils;
 import com.shuzijun.leetcode.plugin.window.dialog.SubmissionsPanel;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -103,15 +104,23 @@ public class SubmissionsPreview extends UserDataHolderBase implements FileEditor
     private void initComponent(String defaultId) {
         isLoad = true;
         ApplicationManager.getApplication().invokeLater(() -> {
-            JBLabel loadingLabel = new JBLabel("Loading......");
-            mySplitter.setFirstComponent(loadingLabel);
-            try {
-                question = QuestionManager.getQuestionByTitleSlug(leetcodeEditor.getTitleSlug(), project);
-
+            mySplitter.setFirstComponent(new JBLabel("Loading......"));
+            AsyncUiUtils.load(project, this, () -> {
+                Question loadedQuestion = QuestionManager.getQuestionByTitleSlug(leetcodeEditor.getTitleSlug(), project);
+                List<Submission> loadedSubmissions = loadedQuestion == null
+                        ? null
+                        : SubmissionManager.getSubmissionService(loadedQuestion.getTitleSlug(), project);
+                return new InitialData(loadedQuestion, loadedSubmissions);
+            }, (data, error) -> {
+                if (error != null) {
+                    mySplitter.setFirstComponent(new JBLabel(error.getMessage()));
+                    return;
+                }
+                question = data.question;
+                submissionList = data.submissions;
                 if (question == null) {
                     mySplitter.setFirstComponent(new JBLabel("No question"));
                 } else {
-                    submissionList = ApplicationManager.getApplication().executeOnPooledThread(() -> SubmissionManager.getSubmissionService(question.getTitleSlug(), project)).get();
                     if (CollectionUtils.isNotEmpty(submissionList)) {
                         table = new JBTable(new SubmissionsPanel.TableModel(submissionList));
                         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -160,11 +169,7 @@ public class SubmissionsPreview extends UserDataHolderBase implements FileEditor
                         mySplitter.setFirstComponent(new JBLabel("No login or no submissions"));
                     }
                 }
-            } catch (Exception e) {
-                mySplitter.setFirstComponent(new JBLabel(e.getMessage()));
-            } finally {
-                mySplitter.remove(loadingLabel);
-            }
+            });
         });
 
     }
@@ -180,13 +185,28 @@ public class SubmissionsPreview extends UserDataHolderBase implements FileEditor
         }
     }
 
-    private void openSubmission(Submission submission) throws InterruptedException, java.util.concurrent.ExecutionException {
-        File file = ApplicationManager.getApplication().executeOnPooledThread(() -> SubmissionManager.openSubmission(submission, question.getTitleSlug(), project, false)).get();
-        if (file == null || !file.exists()) {
-            mySplitter.setSecondComponent(new JBLabel("no submission"));
-        } else {
-            VirtualFile vf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
+    private void openSubmission(Submission submission) {
+        if (question == null) {
+            return;
+        }
+        String titleSlug = question.getTitleSlug();
+        mySplitter.setSecondComponent(new JBLabel("Loading......"));
+        AsyncUiUtils.load(project, this, () -> {
+            File file = SubmissionManager.openSubmission(submission, titleSlug, project, false);
+            return file == null || !file.exists()
+                    ? null
+                    : LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
+        }, (vf, error) -> {
+            if (error != null) {
+                mySplitter.setSecondComponent(new JBLabel(error.getMessage()));
+            } else if (vf == null) {
+                mySplitter.setSecondComponent(new JBLabel("no submission"));
+            } else {
             FileEditorProvider[] editorProviders = FileEditorProviderReflection.getProviders(project, vf);
+            if (editorProviders == null || editorProviders.length == 0) {
+                mySplitter.setSecondComponent(new JBLabel("No editor available for submission"));
+                return;
+            }
             FileEditor newEditor = editorProviders[0].createEditor(project, vf);
             if (newEditor == fileEditor) {
                 return;
@@ -201,7 +221,8 @@ public class SubmissionsPreview extends UserDataHolderBase implements FileEditor
             BorderLayoutPanel secondComponent = JBUI.Panels.simplePanel(fileEditor.getComponent());
             secondComponent.addToTop(createToolbarWrapper(fileEditor.getComponent()));
             mySplitter.setSecondComponent(secondComponent);
-        }
+            }
+        });
     }
 
     private SplitEditorToolbar createToolbarWrapper(JComponent targetComponentForActions) {
@@ -283,7 +304,7 @@ public class SubmissionsPreview extends UserDataHolderBase implements FileEditor
 
     @Override
     public boolean isValid() {
-        return false;
+        return !project.isDisposed();
     }
 
     @Override
@@ -303,9 +324,7 @@ public class SubmissionsPreview extends UserDataHolderBase implements FileEditor
 
     @Override
     public void dispose() {
-        if (fileEditor != null) {
-            Disposer.dispose(fileEditor);
-        }
+        fileEditor = null;
     }
 
     @Override
@@ -314,6 +333,16 @@ public class SubmissionsPreview extends UserDataHolderBase implements FileEditor
             return fileEditor.getFile();
         } else {
             return null;
+        }
+    }
+
+    private static class InitialData {
+        private final Question question;
+        private final List<Submission> submissions;
+
+        private InitialData(Question question, List<Submission> submissions) {
+            this.question = question;
+            this.submissions = submissions;
         }
     }
 }

--- a/src/main/java/com/shuzijun/leetcode/plugin/manager/QuestionManager.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/manager/QuestionManager.java
@@ -16,7 +16,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -321,25 +320,34 @@ public class QuestionManager {
         return getQuestionByTitleSlug(titleSlug,project, false);
     }
 
+    public static Question getCachedQuestionByTitleSlug(String titleSlug, String host) {
+        if (StringUtils.isBlank(titleSlug) || StringUtils.isBlank(host)) {
+            return null;
+        }
+        return questionCache.getIfPresent(host + titleSlug);
+    }
+
     public static Question getQuestionByTitleSlug(String titleSlug, Project project, boolean readOnlyCache) {
 
         if (StringUtils.isBlank(titleSlug)) {
             return null;
         }
         String key = URLUtils.getLeetcodeHost() + titleSlug;
+        Question cachedQuestion = questionCache.getIfPresent(key);
+        if (cachedQuestion != null || readOnlyCache) {
+            return cachedQuestion;
+        }
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            LogUtils.LOG.warn("Skipped loading question on the IDEA UI thread: " + titleSlug);
+            return null;
+        }
         if (questionCache.getIfPresent(key) == null) {
             synchronized (key.intern()) {
                 if (questionCache.getIfPresent(key) == null) {
                     try {
                         Question question = new Question();
                         question.setTitleSlug(titleSlug);
-                        Future<Boolean> questionFuture = ApplicationManager.getApplication().executeOnPooledThread(() -> {
-                            return getQuestion(question, project);
-                        });
-                        if (readOnlyCache) {
-                            return null;
-                        }
-                        if (questionFuture.get()) {
+                        if (getQuestion(question, project)) {
                             questionCache.put(key, question);
                         } else {
                             return null;

--- a/src/main/java/com/shuzijun/leetcode/plugin/manager/ViewManager.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/manager/ViewManager.java
@@ -21,7 +21,6 @@ public class ViewManager {
     }
 
     public static void loadServiceData(NavigatorAction navigatorAction, Project project, String selectTitleSlug) {
-        QuestionManager.getQuestionAllService(project, false);
         PageInfo pageInfo = QuestionManager.getQuestionViewList(project, navigatorAction.getPageInfo());
         if ((pageInfo.getRows() == null || pageInfo.getRows().isEmpty()) && pageInfo.getRowTotal() != 0) {
             MessageUtils.getInstance(project).showErrorMsg("error", PropertiesUtils.getInfo("response.question"));

--- a/src/main/java/com/shuzijun/leetcode/plugin/setting/ProjectConfig.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/setting/ProjectConfig.java
@@ -3,6 +3,7 @@ package com.shuzijun.leetcode.plugin.setting;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.annotations.MapAnnotation;
 import com.shuzijun.leetcode.plugin.model.LeetcodeEditor;
@@ -12,9 +13,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * @author shuzijun
@@ -22,14 +27,17 @@ import java.util.Map;
 @State(name = "LeetcodeEditor" + PluginConstant.ACTION_SUFFIX, storages = {@Storage(value = PluginConstant.ACTION_PREFIX + "/editor.xml")})
 public class ProjectConfig implements PersistentStateComponent<ProjectConfig.InnerState> {
 
-    public Map<String, LeetcodeEditor> idProjectConfig = new HashMap<>();
+    private static final Logger LOG = Logger.getInstance(ProjectConfig.class);
+    private static final String PROJECT_DIR_MACRO = "$PROJECT_DIR$";
+
+    private final ConcurrentMap<String, LeetcodeEditor> idProjectConfig = new ConcurrentHashMap<>();
 
     @Nullable
     public static ProjectConfig getInstance(Project project) {
         return project.getService(ProjectConfig.class);
     }
 
-    private InnerState innerState = new InnerState();
+    private volatile InnerState innerState = new InnerState();
 
     @Nullable
     @Override
@@ -39,31 +47,24 @@ public class ProjectConfig implements PersistentStateComponent<ProjectConfig.Inn
 
     @Override
     public void loadState(@NotNull ProjectConfig.InnerState innerState) {
+        innerState.projectConfig = new ConcurrentHashMap<>(innerState.projectConfig);
         this.innerState = innerState;
         idProjectConfig.clear();
-        Iterator<String> iter = this.innerState.projectConfig.keySet().iterator();
-        while (iter.hasNext()) {
-            String key = iter.next();
-            LeetcodeEditor leetcodeEditor = this.innerState.projectConfig.get(key);
+        this.innerState.projectConfig.forEach((key, leetcodeEditor) -> {
             if (StringUtils.isBlank(leetcodeEditor.getFrontendQuestionId())) {
-                iter.remove();
-                continue;
+                this.innerState.projectConfig.remove(key, leetcodeEditor);
+                return;
             } else if (leetcodeEditor.getFrontendQuestionId().startsWith(URLUtils.leetcodecnOld)) {
                 leetcodeEditor.setHost(URLUtils.leetcodecn);
                 leetcodeEditor.setFrontendQuestionId(leetcodeEditor.getFrontendQuestionId().replace(URLUtils.leetcodecnOld, URLUtils.leetcodecn));
             }
             idProjectConfig.put(leetcodeEditor.getFrontendQuestionId(), leetcodeEditor);
-        }
+        });
     }
 
 
     public LeetcodeEditor getDefEditor(String frontendQuestionId) {
-        LeetcodeEditor leetcodeEditor = idProjectConfig.get(frontendQuestionId);
-        if (leetcodeEditor == null) {
-            leetcodeEditor = new LeetcodeEditor();
-            idProjectConfig.put(frontendQuestionId, leetcodeEditor);
-        }
-        return leetcodeEditor;
+        return idProjectConfig.computeIfAbsent(frontendQuestionId, key -> new LeetcodeEditor());
     }
 
     public void addLeetcodeEditor(LeetcodeEditor leetcodeEditor) {
@@ -86,13 +87,88 @@ public class ProjectConfig implements PersistentStateComponent<ProjectConfig.Inn
         }
     }
 
+    /**
+     * Removes persisted editor records whose source files no longer exist. This is intentionally
+     * called from a background project activity because large, long-lived projects can accumulate
+     * thousands of obsolete records.
+     */
+    public int pruneStaleEntries(@Nullable String projectBasePath) {
+        int removed = 0;
+        for (Map.Entry<String, LeetcodeEditor> entry : innerState.projectConfig.entrySet()) {
+            LeetcodeEditor editor = entry.getValue();
+            String editorPath = StringUtils.defaultIfBlank(editor.getPath(), entry.getKey());
+            Path localPath = resolveLocalPath(editorPath, projectBasePath);
+            Path contentPath = resolveLocalPath(editor.getContentPath(), projectBasePath);
+            boolean sourceMissing = localPath != null && !Files.isRegularFile(localPath);
+            boolean contentMissing = contentPath != null && !Files.isRegularFile(contentPath);
+            if ((sourceMissing || contentMissing)
+                    && innerState.projectConfig.remove(entry.getKey(), editor)) {
+                idProjectConfig.remove(editor.getFrontendQuestionId(), editor);
+                removed++;
+            }
+        }
+
+        // A frontend id can temporarily be associated with more than one path. Restore the live
+        // value after removals without an O(n²) search for every stale entry.
+        innerState.projectConfig.values().forEach(editor -> {
+            if (StringUtils.isNotBlank(editor.getFrontendQuestionId())) {
+                idProjectConfig.put(editor.getFrontendQuestionId(), editor);
+            }
+        });
+        if (removed > 0) {
+            LOG.info("Pruned " + removed + " stale LeetCode editor records");
+        }
+        return removed;
+    }
+
+    public boolean removeEditor(String path) {
+        LeetcodeEditor editor = innerState.projectConfig.remove(path);
+        if (editor == null) {
+            Path target = resolveLocalPath(path, null);
+            if (target != null) {
+                for (Map.Entry<String, LeetcodeEditor> entry : innerState.projectConfig.entrySet()) {
+                    String editorPath = StringUtils.defaultIfBlank(entry.getValue().getPath(), entry.getKey());
+                    if (target.equals(resolveLocalPath(editorPath, null))
+                            && innerState.projectConfig.remove(entry.getKey(), entry.getValue())) {
+                        editor = entry.getValue();
+                        break;
+                    }
+                }
+            }
+        }
+        if (editor != null) {
+            idProjectConfig.remove(editor.getFrontendQuestionId(), editor);
+            return true;
+        }
+        return false;
+    }
+
+    @Nullable
+    static Path resolveLocalPath(@Nullable String path, @Nullable String projectBasePath) {
+        if (StringUtils.isBlank(path) || path.contains("://")) {
+            return null;
+        }
+        String expanded = path;
+        if (expanded.contains(PROJECT_DIR_MACRO)) {
+            if (StringUtils.isBlank(projectBasePath)) {
+                return null;
+            }
+            expanded = expanded.replace(PROJECT_DIR_MACRO, projectBasePath);
+        }
+        try {
+            return Paths.get(expanded).toAbsolutePath().normalize();
+        } catch (InvalidPathException ignored) {
+            return null;
+        }
+    }
+
     public static class InnerState {
         @NotNull
         @MapAnnotation
         public Map<String, LeetcodeEditor> projectConfig;
 
         InnerState() {
-            projectConfig = new HashMap<>();
+            projectConfig = new ConcurrentHashMap<>();
         }
     }
 

--- a/src/main/java/com/shuzijun/leetcode/plugin/utils/AsyncUiUtils.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/utils/AsyncUiUtils.java
@@ -1,0 +1,38 @@
+package com.shuzijun.leetcode.plugin.utils;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
+
+import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
+
+/** Small bridge for blocking work that must publish its result back to Swing. */
+public final class AsyncUiUtils {
+    private AsyncUiUtils() {
+    }
+
+    public static <T> void load(Project project, Disposable owner, Callable<T> background,
+                                BiConsumer<T, Throwable> uiConsumer) {
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            if (project.isDisposed() || Disposer.isDisposed(owner)) {
+                return;
+            }
+            T result = null;
+            Throwable error = null;
+            try {
+                result = background.call();
+            } catch (Exception exception) {
+                error = exception;
+            }
+            T finalResult = result;
+            Throwable finalError = error;
+            ApplicationManager.getApplication().invokeLater(() -> {
+                if (!project.isDisposed() && !Disposer.isDisposed(owner)) {
+                    uiConsumer.accept(finalResult, finalError);
+                }
+            });
+        });
+    }
+}

--- a/src/main/java/com/shuzijun/leetcode/plugin/utils/HttpRequestUtils.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/utils/HttpRequestUtils.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author shuzijun
@@ -37,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 public class HttpRequestUtils {
 
     private static final Cache<String, HttpResponse> httpResponseCache = CacheBuilder.newBuilder().expireAfterWrite(30, TimeUnit.SECONDS).build();
+    private static final AtomicBoolean edtRequestWarningLogged = new AtomicBoolean();
 
     private static MyExecutorHttp executorHttp = new MyExecutorHttp();
     private static LcClient enLcClient = LcClient.builder(HttpClient.SiteEnum.EN).executorHttp(executorHttp).build();
@@ -155,8 +157,18 @@ public class HttpRequestUtils {
         public static HttpResponse processor(HttpRequest httpRequest, HttpRequestUtils.Callable<HttpResponse> callable) {
 
             String key = httpRequest.hashCode() + "";
-            if (httpRequest.isCache() && httpResponseCache.getIfPresent(key) != null) {
-                return httpResponseCache.getIfPresent(key);
+            HttpResponse cachedResponse = httpRequest.isCache() ? httpResponseCache.getIfPresent(key) : null;
+            if (cachedResponse != null) {
+                return cachedResponse;
+            }
+            Application application = ApplicationManager.getApplication();
+            if (application != null && application.isDispatchThread()) {
+                if (edtRequestWarningLogged.compareAndSet(false, true)) {
+                    LogUtils.LOG.warn("Blocked a LeetCode network request on the IDEA UI thread");
+                }
+                HttpResponse rejectedResponse = new HttpResponse();
+                rejectedResponse.setStatusCode(-1);
+                return rejectedResponse;
             }
             if (httpRequest.isCache()) {
                 synchronized (key.intern()) {
@@ -184,14 +196,31 @@ public class HttpRequestUtils {
 
 
     private static class MyExecutorHttp extends DefaultExecutoHttp {
+
+        private static final long CONNECT_TIMEOUT_SECONDS = 8;
+        private static final long READ_WRITE_TIMEOUT_SECONDS = 25;
+        private static final long CALL_TIMEOUT_SECONDS = 30;
+
+        private final OkHttpClient requestClient;
+
+        private MyExecutorHttp() {
+            requestClient = super.getRequestClient().newBuilder()
+                    .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .writeTimeout(READ_WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .readTimeout(READ_WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .callTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .retryOnConnectionFailure(true)
+                    .build();
+        }
+
         @Override
         public OkHttpClient getRequestClient() {
             final HttpConfigurable httpConfigurable = HttpConfigurable.getInstance();
             if (!httpConfigurable.USE_HTTP_PROXY && !httpConfigurable.USE_PROXY_PAC) {
-                return super.getRequestClient();
+                return requestClient;
             }
             final IdeaWideProxySelector ideaWideProxySelector = new IdeaWideProxySelector(httpConfigurable);
-            OkHttpClient.Builder builder = super.getRequestClient().newBuilder().proxySelector(ideaWideProxySelector);
+            OkHttpClient.Builder builder = requestClient.newBuilder().proxySelector(ideaWideProxySelector);
             if (httpConfigurable.PROXY_AUTHENTICATION) {
                 final MyAuthenticator ideaWideAuthenticator = new MyAuthenticator(httpConfigurable);
                 final okhttp3.Authenticator proxyAuthenticator = getProxyAuthenticator(ideaWideAuthenticator);
@@ -294,4 +323,3 @@ public class HttpRequestUtils {
         }
     }
 }
-

--- a/src/main/java/com/shuzijun/leetcode/plugin/window/NavigatorTabsPanel.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/window/NavigatorTabsPanel.java
@@ -26,7 +26,6 @@ import com.shuzijun.leetcode.plugin.window.navigator.TopNavigatorPanel;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -218,19 +217,23 @@ public class NavigatorTabsPanel extends SimpleToolWindowPanel implements Disposa
     public static synchronized void loadUser(boolean login) {
         User user = null;
         if (login) {
-            for (int i = 0; i <= 50; i++) {
+            final int maxAttempts = 3;
+            for (int i = 0; i < maxAttempts; i++) {
                 user = QuestionManager.getUser();
-                if (!user.isSignedIn()) {
-                    try {
-                        Thread.sleep(500 + (i / 10 * 100));
-                    } catch (InterruptedException ignore) {
-                    }
-                } else {
+                if (user.isSignedIn()) {
                     break;
                 }
-                if(i == 50){
-                    LogUtils.LOG.warn("User data is not synchronized");
+                if (i < maxAttempts - 1) {
+                    try {
+                        Thread.sleep(500L * (i + 1));
+                    } catch (InterruptedException ignore) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
                 }
+            }
+            if (user == null || !user.isSignedIn()) {
+                LogUtils.LOG.warn("User data is not synchronized after " + maxAttempts + " attempts");
             }
         } else {
             user = new User();
@@ -241,17 +244,12 @@ public class NavigatorTabsPanel extends SimpleToolWindowPanel implements Disposa
         }
     }
 
-    public static class DisposableMap<K, V> extends HashMap implements Disposable {
-        @Override
-        public synchronized Object put(Object key, Object value) {
-            return super.put(key,value);
-        }
-
-        public synchronized K getOtherKey(K key){
+    public static class DisposableMap<K, V> extends ConcurrentHashMap<K, V> implements Disposable {
+        public K getOtherKey(K key){
             K otherKey = null;
-            for (Object k : this.keySet()) {
+            for (K k : this.keySet()) {
                 if (!k.equals(key)) {
-                    otherKey = key;
+                    otherKey = k;
                     break;
                 }
             }

--- a/src/main/java/com/shuzijun/leetcode/plugin/window/WindowFactory.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/window/WindowFactory.java
@@ -31,7 +31,7 @@ public class WindowFactory implements ToolWindowFactory, DumbAware {
     @Override
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
 
-        ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+        ContentFactory contentFactory = ContentFactory.getInstance();
         JComponent navigatorPanel = new NavigatorTabsPanel(toolWindow, project);
         Content content = contentFactory.createContent(navigatorPanel, "", false);
         toolWindow.getContentManager().addContent(content);

--- a/src/main/java/com/shuzijun/leetcode/plugin/window/login/LoginPanel.java
+++ b/src/main/java/com/shuzijun/leetcode/plugin/window/login/LoginPanel.java
@@ -182,6 +182,10 @@ public class LoginPanel extends DialogWrapper {
                 @Override
                 public void onLoadingStateChange(CefBrowser browser, boolean isLoading, boolean canGoBack, boolean canGoForward) {
 
+                    if (isLoading || successDispose) {
+                        return;
+                    }
+
                     getJBCefCookieManager().getCefCookieManager().visitAllCookies(new CefCookieVisitor() {
 
                         private List<HttpCookie> cookieList = new ArrayList<>();
@@ -196,8 +200,7 @@ public class LoginPanel extends DialogWrapper {
                                 cookieList.add(cookie);
                             }
                             if (count == total - 1) {
-                                if (cookieList.stream().anyMatch(cookie -> cookie.getName().equals("LEETCODE_SESSION")) &&
-                                        !HttpRequestUtils.isLogin(project)) {
+                                if (cookieList.stream().anyMatch(cookie -> cookie.getName().equals("LEETCODE_SESSION"))) {
                                     HttpRequestUtils.setCookie(cookieList);
                                     if (HttpRequestUtils.isLogin(project)) {
                                         HttpLogin.loginSuccess(project, cookieList);

--- a/src/main/kotlin/com/shuzijun/leetcode/plugin/listener/ProjectConfigCleanupActivity.kt
+++ b/src/main/kotlin/com/shuzijun/leetcode/plugin/listener/ProjectConfigCleanupActivity.kt
@@ -1,0 +1,18 @@
+package com.shuzijun.leetcode.plugin.listener
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import com.shuzijun.leetcode.plugin.setting.ProjectConfig
+
+/** Keeps the per-project editor index small without doing filesystem I/O on the UI thread. */
+class ProjectConfigCleanupActivity : StartupActivity, DumbAware {
+    override fun runActivity(project: Project) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            if (!project.isDisposed) {
+                ProjectConfig.getInstance(project)?.pruneStaleEntries(project.basePath)
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,7 +22,6 @@
     </application-components>
 
     <extensions defaultExtensionNs="com.intellij">
-        <postStartupActivity  implementation = "com.shuzijun.leetcode.plugin.listener.RegisterPluginInstallerStateListener"/>
         <errorHandler implementation="com.shuzijun.leetcode.plugin.listener.ErrorReportHandler"/>
         <toolWindow id="Leetcode" secondary="false" icon="LeetCodeEditorIcons.LEETCODE_TOOL_WINDOW" anchor="left"
                     factoryClass="com.shuzijun.leetcode.plugin.window.WindowFactory" />
@@ -62,6 +61,7 @@
         <fileEditorProvider implementation="com.shuzijun.leetcode.plugin.editor.LCVProvider"/>
         <httpRequestHandler implementation="com.shuzijun.leetcode.plugin.editor.PreviewStaticServer"/>
         <postStartupActivity implementation="com.shuzijun.leetcode.plugin.listener.SupportCheck"/>
+        <postStartupActivity implementation="com.shuzijun.leetcode.plugin.listener.ProjectConfigCleanupActivity"/>
     </extensions>
 
     <actions>

--- a/src/test/java/com/shuzijun/leetcode/HttpTest.java
+++ b/src/test/java/com/shuzijun/leetcode/HttpTest.java
@@ -6,6 +6,7 @@ import okhttp3.Authenticator;
 import okhttp3.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.util.List;
 public class HttpTest {
 
     @Test
+    @Ignore("requires a local authenticated proxy on 127.0.0.1:8888")
     public void testVerify() throws LcException, IOException {
 
         DefaultExecutoHttp defaultExecutoHttp = new DefaultExecutoHttp();

--- a/src/test/java/com/shuzijun/leetcode/QuestionViewStatusTest.java
+++ b/src/test/java/com/shuzijun/leetcode/QuestionViewStatusTest.java
@@ -1,0 +1,17 @@
+package com.shuzijun.leetcode;
+
+import com.shuzijun.leetcode.plugin.model.QuestionView;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuestionViewStatusTest {
+
+    @Test
+    public void acceptedStatusUsesUtf8CheckMark() {
+        QuestionView question = new QuestionView();
+        question.setStatus("ac");
+
+        assertEquals("\u2714", question.getStatusSign());
+    }
+}

--- a/src/test/java/com/shuzijun/leetcode/plugin/editor/QuestionEditorTabTitleProviderTest.java
+++ b/src/test/java/com/shuzijun/leetcode/plugin/editor/QuestionEditorTabTitleProviderTest.java
@@ -1,0 +1,23 @@
+package com.shuzijun.leetcode.plugin.editor;
+
+import com.shuzijun.leetcode.plugin.model.Question;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuestionEditorTabTitleProviderTest {
+
+    @Test
+    public void usesLocalFileNameWhenQuestionIsNotCached() {
+        assertEquals("two-sum", QuestionEditorTabTitleProvider.resolveLocalTitle(null, "two-sum"));
+    }
+
+    @Test
+    public void usesCachedQuestionWithoutLoadingFromNetwork() {
+        Question question = new Question();
+        question.setFrontendQuestionId("1");
+        question.setTitle("Two Sum");
+
+        assertEquals("[1]Two Sum", QuestionEditorTabTitleProvider.resolveLocalTitle(question, "two-sum"));
+    }
+}

--- a/src/test/java/com/shuzijun/leetcode/plugin/setting/ProjectConfigTest.java
+++ b/src/test/java/com/shuzijun/leetcode/plugin/setting/ProjectConfigTest.java
@@ -1,0 +1,77 @@
+package com.shuzijun.leetcode.plugin.setting;
+
+import com.shuzijun.leetcode.plugin.model.LeetcodeEditor;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class ProjectConfigTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void prunesMissingSourceAndContentFiles() throws Exception {
+        Path project = temporaryFolder.newFolder("project").toPath();
+        Path liveSource = Files.write(project.resolve("live.java"), "code".getBytes(StandardCharsets.UTF_8));
+        Path liveContent = Files.write(project.resolve("live.lcv"), "content".getBytes(StandardCharsets.UTF_8));
+
+        LeetcodeEditor live = editor("1", liveSource, liveContent);
+        LeetcodeEditor missingSource = editor("2", project.resolve("deleted.java"), liveContent);
+        LeetcodeEditor missingContent = editor("3", liveSource, project.resolve("deleted.lcv"));
+
+        ProjectConfig.InnerState state = new ProjectConfig.InnerState();
+        state.projectConfig.put(live.getPath(), live);
+        state.projectConfig.put(missingSource.getPath(), missingSource);
+        state.projectConfig.put(missingContent.getPath() + "-mapping", missingContent);
+
+        ProjectConfig config = new ProjectConfig();
+        config.loadState(state);
+
+        assertEquals(2, config.pruneStaleEntries(project.toString()));
+        assertSame(live, config.getEditor(live.getPath()));
+        assertNull(config.getEditor(missingSource.getPath()));
+        assertNull(config.getEditor(missingContent.getPath() + "-mapping"));
+        assertSame(live, config.getDefEditor("1"));
+    }
+
+    @Test
+    public void prunesLargeStaleIndexInOnePass() throws Exception {
+        Path project = temporaryFolder.newFolder("large-project").toPath();
+        ProjectConfig.InnerState state = new ProjectConfig.InnerState();
+        for (int i = 0; i < 2500; i++) {
+            Path missing = project.resolve("deleted-" + i + ".java");
+            LeetcodeEditor editor = editor(Integer.toString(i), missing, null);
+            state.projectConfig.put(editor.getPath(), editor);
+        }
+
+        ProjectConfig config = new ProjectConfig();
+        config.loadState(state);
+
+        assertEquals(2500, config.pruneStaleEntries(project.toString()));
+        assertEquals(0, config.getState().projectConfig.size());
+    }
+
+    @Test
+    public void expandsProjectDirectoryMacro() throws Exception {
+        Path project = temporaryFolder.newFolder("macro-project").toPath();
+        assertEquals(project.resolve("src").resolve("answer.java").toAbsolutePath().normalize(),
+                ProjectConfig.resolveLocalPath("$PROJECT_DIR$/src/answer.java", project.toString()));
+    }
+
+    private static LeetcodeEditor editor(String id, Path source, Path content) {
+        LeetcodeEditor editor = new LeetcodeEditor();
+        editor.setFrontendQuestionId(id);
+        editor.setPath(source.toString());
+        editor.setContentPath(content == null ? null : content.toString());
+        return editor;
+    }
+}


### PR DESCRIPTION
## Summary

This PR keeps slow or failed LeetCode operations from blocking IntelliJ's event dispatch thread (EDT), and prevents large, long-lived projects from accumulating an increasingly expensive editor index.

## Problem observed

- Login and question refresh against `leetcode.cn` could take tens of seconds even when the website itself was responsive.
- IntelliJ could become completely unresponsive during startup, editor restoration, preview loading, or generated-file cleanup.
- Projects with many generated question files became progressively slower.
- On Windows, the accepted-question check mark could be compiled as mojibake instead of `✔`.

In a real affected project, `.idea/leetcode/editor.xml` contained 1,049 editor records, but 1,041 of them pointed to files that no longer existed.

## Root cause

Several independent slow paths compounded each other:

1. `QuestionEditorTabTitleProvider` could fetch a question while IDEA was restoring tabs on the EDT. `QuestionManager` then submitted the request to a pooled thread and immediately waited on `Future.get()`, so the UI still blocked. The SDK HTTP client also inherited very long default waits.
2. Every paginated refresh first downloaded the complete question archive, and login synchronization could poll the API up to 51 times.
3. Preview editors used the same `executeOnPooledThread(...).get()` pattern from `invokeLater`, again turning background work into an EDT wait.
4. `ProjectConfig` never removed entries for deleted generated files. File icon/editor callbacks also performed filesystem checks for every candidate file, while "Clear All" recursively refreshed and deleted each file from an `invokeAndWait` block.
5. Java source encoding was not fixed, so the literal check mark depended on the machine's default compiler encoding.

## Changes

- Add bounded HTTP timeouts and reject accidental uncached network requests on the EDT. Tab titles now use cached question data and fall back to the local filename.
- Stop loading the entire question archive before each page refresh, reduce login polling to three bounded attempts, and avoid a redundant login request before installing browser cookies.
- Load note, solution, and submission previews asynchronously, publishing results back to Swing only while the project/editor is still alive.
- Replace the project editor maps with concurrent maps, prune stale source/content records in one pass on a background startup activity, and remove records immediately when generated files are cleared.
- Keep icon/editor acceptance callbacks free of per-file disk probes. Move recursive cleanup off the EDT and refresh VFS once after the operation.
- Disable the non-essential remote "What's New" editor startup activity.
- Compile Java sources as UTF-8, avoid bundling a duplicate Kotlin stdlib, and add the missing wrapper Gradle version property.
- Add regression tests for local tab-title fallback, UTF-8 accepted status, project-directory macro expansion, stale-record cleanup, and a 2,500-record cleanup case. The old proxy-dependent `HttpTest` is explicitly marked as an integration test and skipped by the unit-test task.

## Why this fixes it

The EDT no longer waits for LeetCode responses, recursive filesystem work, or preview futures. Network failures are bounded and remain inside plugin background work, so they cannot freeze the whole IDE. The persisted editor index is also kept proportional to live generated files, and hot icon/editor lookups remain in-memory instead of degrading with project history.

## Validation

- `./gradlew.bat test verifyPluginProjectConfiguration verifyPluginStructure` — successful; 6 tests passed and 1 environment-dependent integration test skipped.
- `./gradlew.bat buildPlugin` — successful; produced `leetcode-editor-8.16.zip`.
- Manual IntelliJ IDEA 2026.1.4 startup test with the affected project — 1,041 stale records pruned, IDE responsiveness check passed, and no plugin severe/freeze log entries were observed.

The repository does not currently contain a `CONTRIBUTING` file or pull request template, so this description follows the existing project structure and standard Markdown conventions.
